### PR TITLE
feat: Add basic ESPHome YAML configuration

### DIFF
--- a/trmnl.yaml
+++ b/trmnl.yaml
@@ -1,0 +1,27 @@
+esphome:
+  name: trmnl
+  friendly_name: trmnl
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+ota:
+
+wifi:
+  ssid: "YOUR_SSID"
+  password: "YOUR_PASSWORD"
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "Trmnl Fallback Hotspot"
+    password: "fallback-password"
+
+captive_portal:


### PR DESCRIPTION
Adds a basic ESPHome YAML configuration file named trmnl.yaml for an ESP32 device. This includes standard components like esphome, esp32, wifi, logger, ota, and api.