### PR TITLE
feat: Add dynamic image generator service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+
+# Docker
+.dockerignore
+docker-compose.override.yml
+
+# Secrets
+.env
+secrets.yaml
+*.secret

--- a/README.md
+++ b/README.md
@@ -1,1 +1,86 @@
 # trmnl_ha_dash
+
+This repository contains configurations for the `trmnl` e-paper display, integrated with Home Assistant. It offers two distinct modes of operation:
+
+1.  **Standalone ESPHome Display:** The default `trmnl.yaml` configuration runs directly on the ESP32 device. It fetches the time from Home Assistant and displays it.
+2.  **Dynamic Image Generator (for `trmnl` plugins):** A separate Python service that generates a dynamic image with weather and calendar data from Home Assistant. This image is designed to be used with the `trmnl` redirect plugin.
+
+---
+
+## Option 1: Standalone ESPHome Display
+
+This is the default mode. The configuration is defined in `trmnl.yaml`.
+
+### Features
+- Displays the current date and time.
+- All rendering is done directly on the ESP32 device.
+
+### Setup
+1.  Configure your Wi-Fi credentials in `trmnl.yaml` or a `secrets.yaml` file.
+2.  Compile and upload the firmware to your ESP32 device using ESPHome.
+
+---
+
+## Option 2: Dynamic Image Generator Service
+
+This is an advanced option that provides a richer display by offloading the image generation to a separate web service. The service fetches weather and calendar information from your Home Assistant instance and renders it into a PNG image.
+
+### Features
+- **Left Side:** Displays the current weather forecast (current temperature, high/low, and condition).
+- **Right Side:** Displays upcoming calendar events.
+- Designed to be used with the `trmnl` redirect plugin, which points to this service's URL.
+
+### Setup and Configuration
+
+The image generator is a Python Flask application located in the `image_generator/` directory. It is designed to be run as a Docker container.
+
+**1. Configure Your Secrets:**
+
+You must provide your Home Assistant details to the service via environment variables. A template is provided in `image_generator/.env.example`.
+
+First, copy the example file to a new `.env` file:
+```bash
+cp image_generator/.env.example image_generator/.env
+```
+
+Next, edit `image_generator/.env` with your specific details:
+
+```ini
+# Home Assistant Configuration
+HA_URL=http://homeassistant.local:8123
+HA_TOKEN=YOUR_LONG_LIVED_ACCESS_TOKEN
+WEATHER_ENTITY=weather.your_weather_entity
+CALENDAR_ENTITY=calendar.your_calendar_entity
+```
+
+- `HA_URL`: The full URL to your Home Assistant instance.
+- `HA_TOKEN`: A Long-Lived Access Token for the Home Assistant API.
+- `WEATHER_ENTITY`: The entity ID for your weather forecast.
+- `CALENDAR_ENTITY`: The entity ID for the calendar you want to display.
+
+**Important:** The `.env` file contains sensitive information. It is included in `.gitignore` to prevent accidental commits.
+
+**2. Build and Run the Docker Container:**
+
+Navigate to the root of the repository and run the following commands:
+
+```bash
+# 1. Build the Docker image
+docker build -t trmnl-image-generator -f image_generator/Dockerfile .
+
+# 2. Run the container
+docker run -d --name trmnl-server --restart always -p 5001:5001 --env-file image_generator/.env trmnl-image-generator
+```
+This will:
+- Build the Docker image with the tag `trmnl-image-generator`.
+- Start a container named `trmnl-server` in detached mode (`-d`).
+- Set it to always restart.
+- Map port 5001 on your host to port 5001 in the container.
+- Load the environment variables from your `.env` file.
+
+### Usage
+
+Once the container is running, the image will be available at:
+`http://<IP_ADDRESS_OF_DOCKER_HOST>:5001/image.png`
+
+You can use this URL with the `trmnl` redirect plugin to display it on your device.

--- a/image_generator/.env.example
+++ b/image_generator/.env.example
@@ -1,0 +1,5 @@
+# Home Assistant Configuration
+HA_URL=http://homeassistant.local:8123
+HA_TOKEN=YOUR_LONG_LIVED_ACCESS_TOKEN
+WEATHER_ENTITY=weather.your_weather_entity
+CALENDAR_ENTITY=calendar.your_calendar_entity

--- a/image_generator/Dockerfile
+++ b/image_generator/Dockerfile
@@ -1,0 +1,30 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install fonts for Pillow
+RUN apt-get update && apt-get install -y libopenjp2-7-dev libtiff-dev libjpeg-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev ttf-mscorefonts-installer fontconfig && \
+    fc-cache -f -v
+
+# Copy the rest of the application's code into the container at /app
+COPY . .
+
+# Make port 5001 available to the world outside this container
+EXPOSE 5001
+
+# Define environment variables (can be overridden at runtime)
+ENV HA_URL="http://homeassistant.local:8123"
+ENV HA_TOKEN=""
+ENV WEATHER_ENTITY=""
+ENV CALENDAR_ENTITY=""
+
+# Run app.py when the container launches
+CMD ["python", "app.py"]

--- a/image_generator/app.py
+++ b/image_generator/app.py
@@ -1,0 +1,110 @@
+import os
+import requests
+from flask import Flask, send_file
+from PIL import Image, ImageDraw, ImageFont
+from io import BytesIO
+from datetime import datetime, timedelta
+
+app = Flask(__name__)
+
+# --- Configuration ---
+HA_URL = os.environ.get("HA_URL", "http://homeassistant.local:8123")
+HA_TOKEN = os.environ.get("HA_TOKEN")
+WEATHER_ENTITY = os.environ.get("WEATHER_ENTITY")
+CALENDAR_ENTITY = os.environ.get("CALENDAR_ENTITY")
+
+# --- Image Settings ---
+IMG_WIDTH = 880
+IMG_HEIGHT = 528
+BG_COLOR = "white"
+FONT_COLOR = "black"
+RED_COLOR = "red"
+try:
+    FONT = ImageFont.truetype("arial.ttf", 24)
+    FONT_BOLD = ImageFont.truetype("arialbd.ttf", 24)
+except IOError:
+    FONT = ImageFont.load_default()
+    FONT_BOLD = ImageFont.load_default()
+
+
+def get_ha_data(endpoint):
+    """Fetches data from Home Assistant API."""
+    headers = {
+        "Authorization": f"Bearer {HA_TOKEN}",
+        "content-type": "application/json",
+    }
+    response = requests.get(f"{HA_URL}/api/{endpoint}", headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
+def create_image():
+    """Creates the image with weather and calendar data."""
+    img = Image.new("RGB", (IMG_WIDTH, IMG_HEIGHT), color=BG_COLOR)
+    draw = ImageDraw.Draw(img)
+
+    # --- Draw Weather (Left Side) ---
+    try:
+        weather_data = get_ha_data(f"states/{WEATHER_ENTITY}")
+        forecast = weather_data.get("attributes", {}).get("forecast", [])[0]
+        temp = weather_data.get("attributes", {}).get("temperature")
+        condition = forecast.get("condition")
+        temp_high = forecast.get("temperature")
+        temp_low = forecast.get("templow")
+
+        draw.text((30, 30), "Weather", font=FONT_BOLD, fill=FONT_COLOR)
+        draw.text((30, 70), f"Now: {temp}°", font=FONT, fill=FONT_COLOR)
+        draw.text((30, 110), f"High: {temp_high}°", font=FONT, fill=RED_COLOR)
+        draw.text((30, 150), f"Low: {temp_low}°", font=FONT, fill=FONT_COLOR)
+        draw.text((30, 190), f"Condition: {condition}", font=FONT, fill=FONT_COLOR)
+    except Exception as e:
+        draw.text((30, 30), "Weather Unavailable", font=FONT_BOLD, fill=RED_COLOR)
+        print(f"Error getting weather: {e}")
+
+
+    # --- Draw Calendar (Right Side) ---
+    try:
+        start_date = datetime.utcnow().isoformat()
+        end_date = (datetime.utcnow() + timedelta(days=1)).isoformat()
+        calendar_data = get_ha_data(f"calendars/{CALENDAR_ENTITY}?start={start_date}Z&end={end_date}Z")
+
+        draw.text((450, 30), "Upcoming Events", font=FONT_BOLD, fill=FONT_COLOR)
+        y_pos = 70
+        if calendar_data:
+            for event in calendar_data[:5]: # Display top 5 events
+                summary = event.get("summary", "No Title")
+                start = event.get("start", {}).get("dateTime", "")
+                if start:
+                    start_dt = datetime.fromisoformat(start)
+                    time_str = start_dt.strftime("%I:%M %p")
+                    draw.text((450, y_pos), f"- {summary} at {time_str}", font=FONT, fill=FONT_COLOR)
+                else:
+                    draw.text((450, y_pos), f"- {summary}", font=FONT, fill=FONT_COLOR)
+                y_pos += 40
+        else:
+            draw.text((450, 70), "No upcoming events.", font=FONT, fill=FONT_COLOR)
+    except Exception as e:
+        draw.text((450, 30), "Calendar Unavailable", font=FONT_BOLD, fill=RED_COLOR)
+        print(f"Error getting calendar: {e}")
+
+
+    # --- Save image to buffer ---
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return buf
+
+
+@app.route("/image.png")
+def serve_image():
+    """Endpoint to serve the generated image."""
+    if not all([HA_TOKEN, WEATHER_ENTITY, CALENDAR_ENTITY]):
+        return "Missing environment variables for Home Assistant configuration.", 500
+    try:
+        image_buffer = create_image()
+        return send_file(image_buffer, mimetype="image/png")
+    except Exception as e:
+        return f"Error generating image: {e}", 500
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5001)

--- a/image_generator/requirements.txt
+++ b/image_generator/requirements.txt
@@ -1,0 +1,3 @@
+requests
+Flask
+Pillow


### PR DESCRIPTION
This commit introduces a new, optional service for generating a dynamic image that can be displayed on the trmnl device using its redirect plugin.

The new service is a Python Flask application located in the `image_generator/` directory. It is designed to be run as a Docker container.

Key features:
- Fetches weather and calendar data from a configured Home Assistant instance.
- Renders the data onto a PNG image, with weather on the left and calendar events on the right.
- Configuration is managed via environment variables (e.g., `HA_URL`, `HA_TOKEN`). An `.env.example` file is provided for guidance.
- Includes a `Dockerfile` for easy containerization and deployment.
- The main `README.md` has been updated to explain this new service as a second option alongside the existing ESPHome configuration, with detailed setup instructions.
- A `.gitignore` file has been added to prevent committing sensitive files like `.env`.