### PR TITLE
Fix: Use absolute path for icon font and display date/weather icon

### DIFF
--- a/image_generator/app.py
+++ b/image_generator/app.py
@@ -53,7 +53,10 @@ def get_font(size, bold=False):
 def get_icon_font(size):
     """Loads the icon font."""
     try:
-        return ImageFont.truetype("image_generator/MaterialDesignIconsDesktop.ttf", size)
+        # Construct an absolute path to the font file
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        font_path = os.path.join(script_dir, "MaterialDesignIconsDesktop.ttf")
+        return ImageFont.truetype(font_path, size)
     except IOError:
         print("Icon font not found, using default font for icons.")
         return ImageFont.load_default()


### PR DESCRIPTION
This commit resolves an issue where the weather icon was not displaying correctly. The problem was caused by the script's inability to locate the icon font file when executed from a different directory.

This commit includes the following changes:

- **Fix:** The `get_icon_font` function in `image_generator/app.py` now constructs an absolute path to the `MaterialDesignIconsDesktop.ttf` file, ensuring it is always found.
- **Feat:** The current date is displayed prominently at the top of the image.
- **Feat:** A Material Design Icon is now used to represent the current weather condition, replacing the previous text-based description.
- A new font file, `MaterialDesignIconsDesktop.ttf`, has been added to the `image_generator` directory.
- The script now maps weather conditions from Home Assistant to the appropriate icon.