### PR TITLE
feat: Generate redirect JSON in workflow

### DIFF
--- a/.github/workflows/generate_image.yml
+++ b/.github/workflows/generate_image.yml
@@ -40,7 +40,8 @@ jobs:
         run: python image_generator/app.py
 
       - name: Generate redirect JSON
-        run: printf '{\n  "url": "https://raw.githubusercontent.com/kevdog114/trmnl_ha_dash/main/trmnl.png",\n  "filename": "trmnl_ha_dash_%s.png",\n  "refresh_rate": 3600\n}\n' "$(date +%Y%m%d%H%M%S)" > trmnl_redirect.json
+        run: |
+          printf '{\n  "url": "https://raw.githubusercontent.com/kevdog114/trmnl_ha_dash/main/trmnl.png",\n  "filename": "trmnl_ha_dash_%s.png",\n  "refresh_rate": 3600\n}\n' "$(date +%Y%m%d%H%M%S)" > trmnl_redirect.json
 
       - name: Commit and push the updated image
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to dynamically generate a `trmnl_redirect.json` file.

This file is intended for use with the `trmnl` redirect plugin. It includes a URL to the dashboard image, a unique filename with a timestamp, and a refresh rate of one hour.

The workflow now performs the following steps:
- Generates the `trmnl.png` image.
- Creates the `trmnl_redirect.json` file with a dynamic timestamp.
- Commits both `trmnl.png` and `trmnl_redirect.json` back to the repository.

This version corrects a YAML syntax error in the previous attempt.