### PR TITLE
feat: Display AI task result on image

### DIFF
--- a/.github/workflows/generate_image.yml
+++ b/.github/workflows/generate_image.yml
@@ -37,6 +37,8 @@ jobs:
           HA_TOKEN: ${{ secrets.HA_TOKEN }}
           WEATHER_ENTITY: ${{ secrets.WEATHER_ENTITY }}
           CALENDAR_ENTITY: ${{ secrets.CALENDAR_ENTITY }}
+          AI_INSTRUCTIONS: ${{ vars.AI_INSTRUCTIONS }}
+          AI_ENTITY_ID: ${{ secrets.AI_ENTITY_ID }}
         run: python image_generator/app.py
 
       - name: Generate redirect JSON


### PR DESCRIPTION
Adds the ability to call a Home Assistant 'ai_task.generate_data' service and display the output at the bottom of the generated dashboard image.

- The image generator script now calls the HA service directly.
- The GitHub Actions workflow has been updated to pass the necessary `AI_INSTRUCTIONS` as a repository variable and `AI_ENTITY_ID` as a secret.