### PR TITLE
fix: Correctly parse nested AI task response

### DIFF
--- a/image_generator/app.py
+++ b/image_generator/app.py
@@ -268,7 +268,8 @@ def generate_image():
             # Case 1: Direct service response (e.g., from a conversation agent)
             if isinstance(ai_data, dict) and "service_response" in ai_data:
                 service_response = ai_data.get("service_response", {})
-                ai_text_to_display = service_response.get("response")
+                # The actual text can be in 'response' or 'data' depending on the agent
+                ai_text_to_display = service_response.get("response") or service_response.get("data")
 
             # Case 2: List of updated entities (e.g., from a task that updates its own state)
             elif isinstance(ai_data, list):


### PR DESCRIPTION
This commit finally resolves the bug where the AI-generated text was not appearing on the image. The previous fixes were insufficient because they did not account for the specific nested structure of the Home Assistant `ai_task.generate_data` service response.

The response was identified from logs to be `{'service_response': {'data': '...'}}`, but the script was looking for a `response` key.

This patch updates the parsing logic in `image_generator/app.py` to correctly look for the `data` key within the `service_response` object, while also retaining the check for the `response` key to handle other possible formats. This makes the feature more robust and resilient to variations in the API output.